### PR TITLE
Fullscreen fix and beat allignment

### DIFF
--- a/get_the_funk.py
+++ b/get_the_funk.py
@@ -80,7 +80,8 @@ class BeamerAsLight:
                 print(self.beat_valid)
                 print(self.beat)
             elif event.key == 9:
-                self.animation_direction = -1 * self.animation_direction
+                self.last_beat = time();
+                self.animation_direction *= -1
             elif event.scancode == 20:
                 self.beat = [2 * b for b in self.beat]
             elif event.scancode == 61:

--- a/get_the_funk.py
+++ b/get_the_funk.py
@@ -19,6 +19,7 @@ class BeamerAsLight:
         self.current_mood = gray
         self.beat = [5.0]
         self.beat_valid = False
+        self.beat_limit = 15
         self.last_beat_pressed_time = None
         self.last_beat = time()
         self.last_frame_time = time()
@@ -31,13 +32,13 @@ class BeamerAsLight:
         pygame.display.set_caption("c't Beamer as Light")
 
     def display_fullscreen(self):
-        modes = pygame.display.list_modes()
-        modes.sort(key=lambda x: x[0]+x[1])
-        self._display_surf = pygame.display.set_mode(modes[-1], pygame.FULLSCREEN)
-        self.size = self.width, self.height = modes[-1]
+        pygame.display.set_mode((self.fullscreen_w,self.fullscreen_h),pygame.FULLSCREEN)
+        self.size = self.width, self.height = self.fullscreen_w, self.fullscreen_h
 
     def init(self):
         pygame.init()
+        self.fullscreen_w = pygame.display.Info().current_w
+        self.fullscreen_h = pygame.display.Info().current_h
         self.display_window()
         return True
 
@@ -63,11 +64,15 @@ class BeamerAsLight:
                     self.display_window()
             elif event.key == pygame.K_RETURN:
                 if self.last_beat_pressed_time:
-                    if not self.beat_valid:
-                        print("New time and new delta: Deleting the previous times.")
-                        self.beat = []
-                    self.beat.append(time() - self.last_beat_pressed_time)
-                    self.beat_valid = True
+                    delta = time() - self.last_beat_pressed_time
+                    if delta < self.beat_limit:
+                        if not self.beat_valid:
+                            print("New time and new delta: Deleting the previous times.")
+                            self.beat = []
+                            self.beat_valid = True
+                        self.beat.append( delta )
+                    else:
+                        print("First delta exceeds limit. Wait for new delta.")
                 else:
                     self.beat_valid = False
                     print("New time but no delta.")

--- a/get_the_funk.py
+++ b/get_the_funk.py
@@ -80,7 +80,7 @@ class BeamerAsLight:
                 print(self.beat_valid)
                 print(self.beat)
             elif event.key == 9:
-                self.last_beat = time();
+                self.last_beat = time()
                 self.animation_direction *= -1
             elif event.scancode == 20:
                 self.beat = [2 * b for b in self.beat]


### PR DESCRIPTION
I fixed a crash when switching to fullscreen mode. It crashed, if the resolution of the monitor/beamer was not set to the highest possible. The other commit changes the behaviour of the "change in direction" keypress, so it is possible to align the animation to the beat.